### PR TITLE
update deps - move browserify and uglify from dev deps to prod deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^1.19.0",
+        "browserify": "^16.3.0",
         "connect-ensure-login": "^0.1.1",
         "connect-flash": "^0.1.1",
         "cookie-parser": "^1.4.4",
@@ -35,11 +36,11 @@
         "passport-local": "^1.0.0",
         "qrcode": "^1.4.0",
         "truffle-hdwallet-provider": "^1.0.15",
+        "uglify": "^0.1.5",
         "uuid": "^3.3.3"
       },
       "devDependencies": {
         "browser-sync": "latest",
-        "browserify": "^16.3.0",
         "gulp": "latest",
         "gulp-autoprefixer": "latest",
         "gulp-clean-css": "latest",
@@ -575,8 +576,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -591,7 +591,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -602,14 +601,12 @@
     "node_modules/acorn-dynamic-import": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "node_modules/acorn-node": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.7.0.tgz",
       "integrity": "sha512-XhahLSsCB6X6CJbe+uNu3Mn9sJBNFxtBN9NLgAOQovfS6Kh0lDUtmlclhjn9CvEK7A7YyRU13PXlNcpSiLI9Yw==",
-      "dev": true,
       "dependencies": {
         "acorn": "^6.1.1",
         "acorn-dynamic-import": "^4.0.0",
@@ -620,8 +617,7 @@
     "node_modules/acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
-      "dev": true
+      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
     },
     "node_modules/aes-js": {
       "version": "3.0.0",
@@ -648,8 +644,7 @@
     "node_modules/amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "node_modules/ansi-align": {
       "version": "2.0.0",
@@ -811,6 +806,28 @@
         "readable-stream": "^2.0.6"
       }
     },
+    "node_modules/argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dependencies": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      }
+    },
+    "node_modules/argparse/node_modules/underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "node_modules/argparse/node_modules/underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -862,8 +879,7 @@
     "node_modules/array-filter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
@@ -910,14 +926,12 @@
     "node_modules/array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "node_modules/array-reduce": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "node_modules/array-slice": {
       "version": "1.1.0",
@@ -982,7 +996,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
-      "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "util": "0.10.3"
@@ -996,14 +1009,12 @@
     "node_modules/assert/node_modules/inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-      "dev": true
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "node_modules/assert/node_modules/util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
       "dependencies": {
         "inherits": "2.0.1"
       }
@@ -1138,8 +1149,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -1416,7 +1426,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1458,7 +1467,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
-      "dev": true,
       "dependencies": {
         "combine-source-map": "~0.8.0",
         "defined": "^1.0.0",
@@ -1472,7 +1480,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
       "dependencies": {
         "resolve": "1.1.7"
       }
@@ -1480,8 +1487,7 @@
     "node_modules/browser-resolve/node_modules/resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "node_modules/browser-sync": {
       "version": "2.26.14",
@@ -1900,7 +1906,6 @@
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.3.0.tgz",
       "integrity": "sha512-BWaaD7alyGZVEBBwSTYx4iJF5DswIGzK17o8ai9w4iKRbYpk3EOiprRHMRRA8DCZFmFeOdx7A385w2XdFvxWmg==",
-      "dev": true,
       "dependencies": {
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
@@ -2013,7 +2018,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "dev": true,
       "dependencies": {
         "pako": "~1.0.5"
       }
@@ -2021,8 +2025,7 @@
     "node_modules/browserify/node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "node_modules/browserslist": {
       "version": "4.14.0",
@@ -2152,8 +2155,7 @@
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-      "dev": true
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "node_modules/busboy": {
       "version": "0.2.14",
@@ -2258,8 +2260,7 @@
     "node_modules/cached-path-relative": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
-      "dev": true
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg=="
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
@@ -2447,6 +2448,19 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "node_modules/coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
@@ -2493,11 +2507,18 @@
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
     },
+    "node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
-      "dev": true,
       "dependencies": {
         "convert-source-map": "~1.1.0",
         "inline-source-map": "~0.6.0",
@@ -2539,8 +2560,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -2626,7 +2646,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
       "dependencies": {
         "date-now": "^0.1.4"
       }
@@ -2640,8 +2659,7 @@
     "node_modules/constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "node_modules/content-disposition": {
       "version": "0.5.3",
@@ -2659,8 +2677,7 @@
     "node_modules/convert-source-map": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-      "dev": true
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
     },
     "node_modules/cookie": {
       "version": "0.3.1",
@@ -2840,8 +2857,7 @@
     "node_modules/dash-ast": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
-      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
-      "dev": true
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -2854,8 +2870,7 @@
     "node_modules/date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "node_modules/dateformat": {
       "version": "2.2.0",
@@ -3126,8 +3141,7 @@
     "node_modules/defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3149,7 +3163,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-      "dev": true,
       "dependencies": {
         "JSONStream": "^1.0.3",
         "shasum": "^1.0.0",
@@ -3187,7 +3200,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
       "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
-      "dev": true,
       "dependencies": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
@@ -3259,8 +3271,7 @@
     "node_modules/domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "node_modules/dot-prop": {
       "version": "4.2.1",
@@ -3283,7 +3294,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
@@ -3551,6 +3561,18 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "node_modules/esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3663,6 +3685,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -3672,8 +3699,7 @@
     "node_modules/events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
-      "dev": true
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
     },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
@@ -3703,6 +3729,14 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
@@ -4245,8 +4279,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "1.2.9",
@@ -5154,8 +5187,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gauge": {
       "version": "2.7.4",
@@ -5220,8 +5252,7 @@
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
-      "dev": true
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -5245,6 +5276,14 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "node_modules/getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -5257,7 +5296,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5415,6 +5453,453 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "node_modules/grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dependencies": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-clean": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
+      "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
+      "dependencies": {
+        "rimraf": "~2.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-clean/node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/grunt-contrib-concat": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.3.0.tgz",
+      "integrity": "sha1-SPoNQzbSm2U62CJaa9b4VrRIPjI=",
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-copy": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
+      "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-cssmin": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.6.1.tgz",
+      "integrity": "sha1-U05jK/4ZUhshw2RncVe4sR4XPvw=",
+      "dependencies": {
+        "clean-css": "~1.0.4",
+        "grunt-lib-contrib": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-cssmin/node_modules/clean-css": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-1.0.12.tgz",
+      "integrity": "sha1-5uDZd4YEZjY9kRChdCPSfNaHQwA=",
+      "dependencies": {
+        "commander": "1.3.x"
+      },
+      "bin": {
+        "cleancss": "bin/cleancss"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/grunt-contrib-cssmin/node_modules/commander": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+      "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+      "dependencies": {
+        "keypress": "0.1.x"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/grunt-contrib-uglify": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.2.4.tgz",
+      "integrity": "sha1-URE/KKckMlIeNeY/fxiiUf2i/Uk=",
+      "dependencies": {
+        "grunt-lib-contrib": "~0.6.1",
+        "uglify-js": "~2.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": "~0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-uglify/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "node_modules/grunt-contrib-uglify/node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-contrib-uglify/node_modules/source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-contrib-uglify/node_modules/uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+      "dependencies": {
+        "async": "~0.2.6",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt-contrib-uglify/node_modules/yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/grunt-css-url-replace": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/grunt-css-url-replace/-/grunt-css-url-replace-0.2.7.tgz",
+      "integrity": "sha1-lcZb/x78FTvxfHlf0+EiLH+kp0U=",
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dependencies": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dependencies": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dependencies": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt-legacy-util/node_modules/async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util/node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt-legacy-util/node_modules/underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt-legacy-util/node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/grunt-lib-contrib": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.6.1.tgz",
+      "integrity": "sha1-P1att9oG6BR5XuJBWw6+X7iQPrs=",
+      "dependencies": {
+        "zlib-browserify": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/grunt/node_modules/async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dependencies": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/grunt/node_modules/findup-sync/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/findup-sync/node_modules/lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt/node_modules/findup-sync/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dependencies": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/glob/node_modules/inherits": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+    },
+    "node_modules/grunt/node_modules/graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/grunt/node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/grunt/node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
+    "node_modules/grunt/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/grunt/node_modules/underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/grunt/node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "bin": {
+        "which": "bin/which"
+      }
     },
     "node_modules/gulp": {
       "version": "4.0.2",
@@ -6099,7 +6584,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       }
@@ -6258,6 +6742,14 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -6267,8 +6759,7 @@
     "node_modules/htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
-      "dev": true
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
@@ -6324,8 +6815,7 @@
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-      "dev": true
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -6411,7 +6901,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6432,7 +6921,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-      "dev": true,
       "dependencies": {
         "source-map": "~0.5.3"
       }
@@ -6441,7 +6929,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
       "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
-      "dev": true,
       "dependencies": {
         "acorn-node": "^1.5.2",
         "combine-source-map": "^0.8.0",
@@ -6458,8 +6945,7 @@
     "node_modules/insert-module-globals/node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -6533,8 +7019,7 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-ci": {
       "version": "1.2.1",
@@ -6848,6 +7333,21 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
+    "node_modules/js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dependencies": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -6872,7 +7372,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-      "dev": true,
       "dependencies": {
         "jsonify": "~0.0.0"
       }
@@ -6900,20 +7399,17 @@
     "node_modules/jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -6936,6 +7432,11 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "node_modules/keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+    },
     "node_modules/keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -6957,7 +7458,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
       "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
@@ -7362,8 +7862,7 @@
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
     "node_modules/lodash.restparam": {
       "version": "3.6.1",
@@ -7674,7 +8173,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       }
@@ -7763,7 +8261,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.1.tgz",
       "integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
-      "dev": true,
       "dependencies": {
         "browser-resolve": "^1.7.0",
         "cached-path-relative": "^1.0.2",
@@ -8105,7 +8602,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
       "dependencies": {
         "abbrev": "1"
       }
@@ -8375,8 +8871,7 @@
     "node_modules/os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -8484,7 +8979,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-      "dev": true,
       "dependencies": {
         "path-platform": "~0.11.15"
       }
@@ -8606,8 +9100,7 @@
     "node_modules/path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-      "dev": true
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
@@ -8623,8 +9116,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "node_modules/path-is-inside": {
       "version": "1.0.2",
@@ -8641,14 +9133,12 @@
     "node_modules/path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "node_modules/path-platform": {
       "version": "0.11.15",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
-      "dev": true
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
     },
     "node_modules/path-root": {
       "version": "0.1.1",
@@ -8954,14 +9444,12 @@
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-      "dev": true
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "node_modules/random-bytes": {
       "version": "1.0.0",
@@ -9023,7 +9511,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-      "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
@@ -9276,7 +9763,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-      "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
       }
@@ -9696,7 +10182,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "dev": true,
       "dependencies": {
         "json-stable-stringify": "~0.0.0",
         "sha.js": "~2.4.4"
@@ -9721,7 +10206,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
       "dependencies": {
         "array-filter": "~0.0.0",
         "array-map": "~0.0.0",
@@ -9734,6 +10218,11 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "node_modules/signal-exit": {
       "version": "3.0.2",
@@ -9989,8 +10478,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "node_modules/source-map-resolve": {
       "version": "0.5.2",
@@ -10123,7 +10611,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
-      "dev": true,
       "dependencies": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
@@ -10133,7 +10620,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "dev": true,
       "dependencies": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -10149,7 +10635,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-      "dev": true,
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -10168,7 +10653,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
       "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.2"
@@ -10207,7 +10691,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10290,7 +10773,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.1.0"
       }
@@ -10410,7 +10892,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
-      "dev": true,
       "dependencies": {
         "acorn-node": "^1.2.0"
       }
@@ -10526,7 +11007,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -10557,7 +11037,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "dev": true,
       "dependencies": {
         "process": "~0.11.0"
       }
@@ -10565,8 +11044,7 @@
     "node_modules/timers-browserify/node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "node_modules/timers-ext": {
       "version": "0.1.7",
@@ -10610,8 +11088,7 @@
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-      "dev": true
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "node_modules/to-buffer": {
       "version": "1.1.1",
@@ -10796,8 +11273,7 @@
     "node_modules/tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-      "dev": true
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -10858,6 +11334,26 @@
         "node": "*"
       }
     },
+    "node_modules/uglify": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/uglify/-/uglify-0.1.5.tgz",
+      "integrity": "sha1-iI1X770b+n+tieEdBpl16WgtVNI=",
+      "dependencies": {
+        "commander": "*",
+        "grunt": "0.4.5",
+        "grunt-contrib-clean": "0.5.0",
+        "grunt-contrib-concat": "0.3.0",
+        "grunt-contrib-copy": "0.5.0",
+        "grunt-contrib-cssmin": "0.6.1",
+        "grunt-contrib-uglify": "0.2.4",
+        "grunt-css-url-replace": "*",
+        "underscore": "1.4.x",
+        "underscore.string": "2.3.3"
+      },
+      "bin": {
+        "uglify": "bin/uglify"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -10873,6 +11369,16 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+    },
+    "node_modules/uglify/node_modules/underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",
@@ -10890,8 +11396,7 @@
     "node_modules/umd": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
-      "dev": true
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
@@ -10912,7 +11417,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
       "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
-      "dev": true,
       "dependencies": {
         "acorn-node": "^1.3.0",
         "dash-ast": "^1.0.0",
@@ -10943,6 +11447,14 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/undertaker": {
       "version": "1.2.1",
@@ -11103,7 +11615,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -11133,8 +11644,7 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -11168,7 +11678,6 @@
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dev": true,
       "dependencies": {
         "inherits": "2.0.3"
       }
@@ -11181,8 +11690,7 @@
     "node_modules/util/node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -11335,8 +11843,7 @@
     "node_modules/vm-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
-      "dev": true
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
     "node_modules/watchify": {
       "version": "3.11.1",
@@ -11911,6 +12418,22 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -12108,6 +12631,11 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
+    },
+    "node_modules/zlib-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
+      "integrity": "sha1-T6akXQDbwV8xikr6HZr8Aljhdsw="
     }
   },
   "dependencies": {
@@ -12531,8 +13059,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -12546,20 +13073,17 @@
     "acorn": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "acorn-node": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.7.0.tgz",
       "integrity": "sha512-XhahLSsCB6X6CJbe+uNu3Mn9sJBNFxtBN9NLgAOQovfS6Kh0lDUtmlclhjn9CvEK7A7YyRU13PXlNcpSiLI9Yw==",
-      "dev": true,
       "requires": {
         "acorn": "^6.1.1",
         "acorn-dynamic-import": "^4.0.0",
@@ -12570,8 +13094,7 @@
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
-      "dev": true
+      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
     },
     "aes-js": {
       "version": "3.0.0",
@@ -12598,8 +13121,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -12767,6 +13289,27 @@
         "readable-stream": "^2.0.6"
       }
     },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "requires": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+        }
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -12818,8 +13361,7 @@
     "array-filter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -12870,14 +13412,12 @@
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-slice": {
       "version": "1.1.0",
@@ -12944,7 +13484,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
-      "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "util": "0.10.3"
@@ -12953,14 +13492,12 @@
         "inherits": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "util": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "dev": true,
           "requires": {
             "inherits": "2.0.1"
           }
@@ -13099,8 +13636,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -13377,7 +13913,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -13421,7 +13956,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
-      "dev": true,
       "requires": {
         "combine-source-map": "~0.8.0",
         "defined": "^1.0.0",
@@ -13435,7 +13969,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -13443,8 +13976,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -13774,7 +14306,6 @@
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.3.0.tgz",
       "integrity": "sha512-BWaaD7alyGZVEBBwSTYx4iJF5DswIGzK17o8ai9w4iKRbYpk3EOiprRHMRRA8DCZFmFeOdx7A385w2XdFvxWmg==",
-      "dev": true,
       "requires": {
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
@@ -13829,8 +14360,7 @@
         "process": {
           "version": "0.11.10",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
       }
     },
@@ -13895,7 +14425,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "dev": true,
       "requires": {
         "pako": "~1.0.5"
       }
@@ -14023,8 +14552,7 @@
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-      "dev": true
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "busboy": {
       "version": "0.2.14",
@@ -14121,8 +14649,7 @@
     "cached-path-relative": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
-      "dev": true
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -14314,6 +14841,11 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ="
+    },
     "collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
@@ -14360,11 +14892,15 @@
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
     },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
-      "dev": true,
       "requires": {
         "convert-source-map": "~1.1.0",
         "inline-source-map": "~0.6.0",
@@ -14406,8 +14942,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -14494,7 +15029,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
       "requires": {
         "date-now": "^0.1.4"
       }
@@ -14508,8 +15042,7 @@
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -14527,8 +15060,7 @@
     "convert-source-map": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-      "dev": true
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
     },
     "cookie": {
       "version": "0.3.1",
@@ -14708,8 +15240,7 @@
     "dash-ast": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
-      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
-      "dev": true
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -14722,8 +15253,7 @@
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "dateformat": {
       "version": "2.2.0",
@@ -14971,8 +15501,7 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -14994,7 +15523,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-      "dev": true,
       "requires": {
         "JSONStream": "^1.0.3",
         "shasum": "^1.0.0",
@@ -15032,7 +15560,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
       "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
-      "dev": true,
       "requires": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
@@ -15106,8 +15633,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "dot-prop": {
       "version": "4.2.1",
@@ -15127,7 +15653,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
       }
@@ -15388,6 +15913,11 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -15502,6 +16032,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -15511,8 +16046,7 @@
     "events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
-      "dev": true
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -15542,6 +16076,11 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -16088,8 +16627,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -16786,8 +17324,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -16854,8 +17391,7 @@
     "get-assigned-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
-      "dev": true
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -16879,6 +17415,11 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -16891,7 +17432,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17051,6 +17591,331 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "requires": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk="
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "requires": {
+            "glob": "~3.2.9",
+            "lodash": "~2.4.1"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "requires": {
+                "inherits": "2",
+                "minimatch": "0.3"
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+              "requires": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "requires": {
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
+        },
+        "which": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
+      "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
+      "requires": {
+        "rimraf": "~2.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        }
+      }
+    },
+    "grunt-contrib-concat": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.3.0.tgz",
+      "integrity": "sha1-SPoNQzbSm2U62CJaa9b4VrRIPjI=",
+      "requires": {}
+    },
+    "grunt-contrib-copy": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
+      "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
+      "requires": {}
+    },
+    "grunt-contrib-cssmin": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.6.1.tgz",
+      "integrity": "sha1-U05jK/4ZUhshw2RncVe4sR4XPvw=",
+      "requires": {
+        "clean-css": "~1.0.4",
+        "grunt-lib-contrib": "~0.6.0"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-1.0.12.tgz",
+          "integrity": "sha1-5uDZd4YEZjY9kRChdCPSfNaHQwA=",
+          "requires": {
+            "commander": "1.3.x"
+          }
+        },
+        "commander": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+          "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+          "requires": {
+            "keypress": "0.1.x"
+          }
+        }
+      }
+    },
+    "grunt-contrib-uglify": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.2.4.tgz",
+      "integrity": "sha1-URE/KKckMlIeNeY/fxiiUf2i/Uk=",
+      "requires": {
+        "grunt-lib-contrib": "~0.6.1",
+        "uglify-js": "~2.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "source-map": {
+          "version": "0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.24",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+          "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+          "requires": {
+            "async": "~0.2.6",
+            "source-map": "0.1.34",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.5.4"
+          }
+        },
+        "yargs": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+          "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+          "requires": {
+            "camelcase": "^1.0.2",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0",
+            "wordwrap": "0.0.2"
+          }
+        }
+      }
+    },
+    "grunt-css-url-replace": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/grunt-css-url-replace/-/grunt-css-url-replace-0.2.7.tgz",
+      "integrity": "sha1-lcZb/x78FTvxfHlf0+EiLH+kp0U=",
+      "requires": {}
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "requires": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "requires": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "requires": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
+        },
+        "which": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+        }
+      }
+    },
+    "grunt-lib-contrib": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.6.1.tgz",
+      "integrity": "sha1-P1att9oG6BR5XuJBWw6+X7iQPrs=",
+      "requires": {
+        "zlib-browserify": "0.0.1"
+      }
     },
     "gulp": {
       "version": "4.0.2",
@@ -17723,7 +18588,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -17882,6 +18746,11 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -17891,8 +18760,7 @@
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
-      "dev": true
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -17947,8 +18815,7 @@
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-      "dev": true
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -18027,7 +18894,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18048,7 +18914,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-      "dev": true,
       "requires": {
         "source-map": "~0.5.3"
       }
@@ -18057,7 +18922,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
       "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
-      "dev": true,
       "requires": {
         "acorn-node": "^1.5.2",
         "combine-source-map": "^0.8.0",
@@ -18074,8 +18938,7 @@
         "process": {
           "version": "0.11.10",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
       }
     },
@@ -18150,8 +19013,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-ci": {
       "version": "1.2.1",
@@ -18461,6 +19323,15 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -18485,7 +19356,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-      "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
       }
@@ -18513,20 +19383,17 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -18549,6 +19416,11 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -18567,7 +19439,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
       "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
@@ -18926,8 +19797,7 @@
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -19239,7 +20109,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -19325,7 +20194,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.1.tgz",
       "integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
-      "dev": true,
       "requires": {
         "browser-resolve": "^1.7.0",
         "cached-path-relative": "^1.0.2",
@@ -19666,7 +20534,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -19933,8 +20800,7 @@
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -20036,7 +20902,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-      "dev": true,
       "requires": {
         "path-platform": "~0.11.15"
       }
@@ -20158,8 +21023,7 @@
     "path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-      "dev": true
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -20175,8 +21039,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -20193,14 +21056,12 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-platform": {
       "version": "0.11.15",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
-      "dev": true
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
     },
     "path-root": {
       "version": "0.1.1",
@@ -20488,14 +21349,12 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-      "dev": true
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -20557,7 +21416,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
       }
@@ -20816,7 +21674,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -21238,7 +22095,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "dev": true,
       "requires": {
         "json-stable-stringify": "~0.0.0",
         "sha.js": "~2.4.4"
@@ -21263,7 +22119,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
       "requires": {
         "array-filter": "~0.0.0",
         "array-map": "~0.0.0",
@@ -21276,6 +22131,11 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -21541,8 +22401,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -21677,7 +22536,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
-      "dev": true,
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
@@ -21687,7 +22545,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "dev": true,
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -21703,7 +22560,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-      "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -21722,7 +22578,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
       "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.2"
@@ -21752,7 +22607,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -21831,7 +22685,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "dev": true,
       "requires": {
         "minimist": "^1.1.0"
       }
@@ -21944,7 +22797,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
-      "dev": true,
       "requires": {
         "acorn-node": "^1.2.0"
       }
@@ -22044,7 +22896,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -22075,7 +22926,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "dev": true,
       "requires": {
         "process": "~0.11.0"
       },
@@ -22083,8 +22933,7 @@
         "process": {
           "version": "0.11.10",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
       }
     },
@@ -22127,8 +22976,7 @@
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-      "dev": true
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "to-buffer": {
       "version": "1.1.1",
@@ -22313,8 +23161,7 @@
     "tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-      "dev": true
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -22362,6 +23209,30 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
       "dev": true
     },
+    "uglify": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/uglify/-/uglify-0.1.5.tgz",
+      "integrity": "sha1-iI1X770b+n+tieEdBpl16WgtVNI=",
+      "requires": {
+        "commander": "*",
+        "grunt": "0.4.5",
+        "grunt-contrib-clean": "0.5.0",
+        "grunt-contrib-concat": "0.3.0",
+        "grunt-contrib-copy": "0.5.0",
+        "grunt-contrib-cssmin": "0.6.1",
+        "grunt-contrib-uglify": "0.2.4",
+        "grunt-css-url-replace": "*",
+        "underscore": "1.4.x",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+        }
+      }
+    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -22380,6 +23251,11 @@
         }
       }
     },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -22396,8 +23272,7 @@
     "umd": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
-      "dev": true
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",
@@ -22418,7 +23293,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
       "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
-      "dev": true,
       "requires": {
         "acorn-node": "^1.3.0",
         "dash-ast": "^1.0.0",
@@ -22451,6 +23325,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
     },
     "undertaker": {
       "version": "1.2.1",
@@ -22617,7 +23496,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -22626,8 +23504,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
@@ -22680,7 +23557,6 @@
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       },
@@ -22688,8 +23564,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -22848,8 +23723,7 @@
     "vm-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
-      "dev": true
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
     "watchify": {
       "version": "3.11.1",
@@ -23350,6 +24224,16 @@
         }
       }
     },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -23521,6 +24405,11 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
+    },
+    "zlib-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
+      "integrity": "sha1-T6akXQDbwV8xikr6HZr8Aljhdsw="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "passport-local": "^1.0.0",
         "qrcode": "^1.4.0",
         "truffle-hdwallet-provider": "^1.0.15",
-        "uglify": "^0.1.5",
+        "uglify-js": "^3.13.7",
         "uuid": "^3.3.3"
       },
       "devDependencies": {
@@ -54,7 +54,6 @@
         "gulp-uglify": "latest",
         "nodemon": "^1.19.1",
         "truffle-flattener": "^1.4.4",
-        "uglify-js": "^3.6.0",
         "watchify": "^3.11.1"
       },
       "engines": {
@@ -576,7 +575,8 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -644,7 +644,8 @@
     "node_modules/amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "node_modules/ansi-align": {
       "version": "2.0.0",
@@ -804,28 +805,6 @@
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-      "dependencies": {
-        "underscore": "~1.7.0",
-        "underscore.string": "~2.4.0"
-      }
-    },
-    "node_modules/argparse/node_modules/underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-    },
-    "node_modules/argparse/node_modules/underscore.string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/arr-diff": {
@@ -2448,19 +2427,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "node_modules/coffee-script": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
-      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
@@ -2506,14 +2472,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combine-source-map": {
       "version": "0.8.0",
@@ -3561,18 +3519,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "node_modules/esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3685,11 +3631,6 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "node_modules/eventemitter2": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -3729,14 +3670,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
-    },
-    "node_modules/exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
@@ -5276,14 +5209,6 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
-    "node_modules/getobject": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -5453,453 +5378,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "node_modules/grunt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
-      "dependencies": {
-        "async": "~0.1.22",
-        "coffee-script": "~1.3.3",
-        "colors": "~0.6.2",
-        "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.1.2",
-        "getobject": "~0.1.0",
-        "glob": "~3.1.21",
-        "grunt-legacy-log": "~0.1.0",
-        "grunt-legacy-util": "~0.2.0",
-        "hooker": "~0.2.3",
-        "iconv-lite": "~0.2.11",
-        "js-yaml": "~2.0.5",
-        "lodash": "~0.9.2",
-        "minimatch": "~0.2.12",
-        "nopt": "~1.0.10",
-        "rimraf": "~2.2.8",
-        "underscore.string": "~2.2.1",
-        "which": "~1.0.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/grunt-contrib-clean": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
-      "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
-      "dependencies": {
-        "rimraf": "~2.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "peerDependencies": {
-        "grunt": "~0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-clean/node_modules/rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/grunt-contrib-concat": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.3.0.tgz",
-      "integrity": "sha1-SPoNQzbSm2U62CJaa9b4VrRIPjI=",
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "peerDependencies": {
-        "grunt": "~0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-copy": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
-      "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "peerDependencies": {
-        "grunt": "~0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-cssmin": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.6.1.tgz",
-      "integrity": "sha1-U05jK/4ZUhshw2RncVe4sR4XPvw=",
-      "dependencies": {
-        "clean-css": "~1.0.4",
-        "grunt-lib-contrib": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "peerDependencies": {
-        "grunt": "~0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-cssmin/node_modules/clean-css": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-1.0.12.tgz",
-      "integrity": "sha1-5uDZd4YEZjY9kRChdCPSfNaHQwA=",
-      "dependencies": {
-        "commander": "1.3.x"
-      },
-      "bin": {
-        "cleancss": "bin/cleancss"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/grunt-contrib-cssmin/node_modules/commander": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
-      "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
-      "dependencies": {
-        "keypress": "0.1.x"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/grunt-contrib-uglify": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.2.4.tgz",
-      "integrity": "sha1-URE/KKckMlIeNeY/fxiiUf2i/Uk=",
-      "dependencies": {
-        "grunt-lib-contrib": "~0.6.1",
-        "uglify-js": "~2.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "peerDependencies": {
-        "grunt": "~0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-uglify/node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-    },
-    "node_modules/grunt-contrib-uglify/node_modules/camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/grunt-contrib-uglify/node_modules/source-map": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-      "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/grunt-contrib-uglify/node_modules/uglify-js": {
-      "version": "2.4.24",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
-      "dependencies": {
-        "async": "~0.2.6",
-        "source-map": "0.1.34",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.5.4"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-uglify/node_modules/yargs": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
-      "dependencies": {
-        "camelcase": "^1.0.2",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0",
-        "wordwrap": "0.0.2"
-      }
-    },
-    "node_modules/grunt-css-url-replace": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/grunt-css-url-replace/-/grunt-css-url-replace-0.2.7.tgz",
-      "integrity": "sha1-lcZb/x78FTvxfHlf0+EiLH+kp0U=",
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "peerDependencies": {
-        "grunt": ">=0.4.0"
-      }
-    },
-    "node_modules/grunt-legacy-log": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
-      "dependencies": {
-        "colors": "~0.6.2",
-        "grunt-legacy-log-utils": "~0.1.1",
-        "hooker": "~0.2.3",
-        "lodash": "~2.4.1",
-        "underscore.string": "~2.3.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/grunt-legacy-log-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
-      "dependencies": {
-        "colors": "~0.6.2",
-        "lodash": "~2.4.1",
-        "underscore.string": "~2.3.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-      "engines": [
-        "node",
-        "rhino"
-      ]
-    },
-    "node_modules/grunt-legacy-log/node_modules/lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-      "engines": [
-        "node",
-        "rhino"
-      ]
-    },
-    "node_modules/grunt-legacy-util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
-      "dependencies": {
-        "async": "~0.1.22",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
-        "hooker": "~0.2.3",
-        "lodash": "~0.9.2",
-        "underscore.string": "~2.2.1",
-        "which": "~1.0.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/grunt-legacy-util/node_modules/async": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt-legacy-util/node_modules/lodash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "engines": [
-        "node",
-        "rhino"
-      ]
-    },
-    "node_modules/grunt-legacy-util/node_modules/underscore.string": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt-legacy-util/node_modules/which": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/grunt-lib-contrib": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.6.1.tgz",
-      "integrity": "sha1-P1att9oG6BR5XuJBWw6+X7iQPrs=",
-      "dependencies": {
-        "zlib-browserify": "0.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/grunt/node_modules/async": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/dateformat": {
-      "version": "1.0.2-1.2.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/findup-sync": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
-      "dependencies": {
-        "glob": "~3.2.9",
-        "lodash": "~2.4.1"
-      },
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/grunt/node_modules/findup-sync/node_modules/glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "dependencies": {
-        "inherits": "2",
-        "minimatch": "0.3"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/findup-sync/node_modules/lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-      "engines": [
-        "node",
-        "rhino"
-      ]
-    },
-    "node_modules/grunt/node_modules/findup-sync/node_modules/minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/glob": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-      "dependencies": {
-        "graceful-fs": "~1.2.0",
-        "inherits": "1",
-        "minimatch": "~0.2.11"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/glob/node_modules/inherits": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
-    },
-    "node_modules/grunt/node_modules/graceful-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/grunt/node_modules/iconv-lite": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/grunt/node_modules/lodash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "engines": [
-        "node",
-        "rhino"
-      ]
-    },
-    "node_modules/grunt/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-    },
-    "node_modules/grunt/node_modules/minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/grunt/node_modules/underscore.string": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/which": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/gulp": {
       "version": "4.0.2",
@@ -6742,14 +6220,6 @@
         "parse-passwd": "^1.0.0"
       }
     },
-    "node_modules/hooker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -7333,21 +6803,6 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
-    "node_modules/js-yaml": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
-      "dependencies": {
-        "argparse": "~ 0.1.11",
-        "esprima": "~ 1.0.2"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      },
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -7431,11 +6886,6 @@
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
-    },
-    "node_modules/keypress": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -8602,6 +8052,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
       "dependencies": {
         "abbrev": "1"
       }
@@ -10219,11 +9670,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "node_modules/sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-    },
     "node_modules/signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -11334,51 +10780,16 @@
         "node": "*"
       }
     },
-    "node_modules/uglify": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/uglify/-/uglify-0.1.5.tgz",
-      "integrity": "sha1-iI1X770b+n+tieEdBpl16WgtVNI=",
-      "dependencies": {
-        "commander": "*",
-        "grunt": "0.4.5",
-        "grunt-contrib-clean": "0.5.0",
-        "grunt-contrib-concat": "0.3.0",
-        "grunt-contrib-copy": "0.5.0",
-        "grunt-contrib-cssmin": "0.6.1",
-        "grunt-contrib-uglify": "0.2.4",
-        "grunt-css-url-replace": "*",
-        "underscore": "1.4.x",
-        "underscore.string": "2.3.3"
-      },
-      "bin": {
-        "uglify": "bin/uglify"
-      }
-    },
     "node_modules/uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-      "dev": true,
-      "dependencies": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+      "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
-    },
-    "node_modules/uglify-js/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "node_modules/uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
-    },
-    "node_modules/uglify/node_modules/underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",
@@ -11447,14 +10858,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
-    "node_modules/underscore.string": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/undertaker": {
       "version": "1.2.1",
@@ -12418,22 +11821,6 @@
         "ansi-regex": "^3.0.0"
       }
     },
-    "node_modules/window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -12631,11 +12018,6 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
-    },
-    "node_modules/zlib-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
-      "integrity": "sha1-T6akXQDbwV8xikr6HZr8Aljhdsw="
     }
   },
   "dependencies": {
@@ -13059,7 +12441,8 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -13121,7 +12504,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -13287,27 +12671,6 @@
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
-      }
-    },
-    "argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-      "requires": {
-        "underscore": "~1.7.0",
-        "underscore.string": "~2.4.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-        },
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
-        }
       }
     },
     "arr-diff": {
@@ -14841,11 +14204,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ="
-    },
     "collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
@@ -14891,11 +14249,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
-    },
-    "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
     },
     "combine-source-map": {
       "version": "0.8.0",
@@ -15913,11 +15266,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -16032,11 +15380,6 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "eventemitter2": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -16076,11 +15419,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -17415,11 +16753,6 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
-    "getobject": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw="
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -17591,331 +16924,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "grunt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
-      "requires": {
-        "async": "~0.1.22",
-        "coffee-script": "~1.3.3",
-        "colors": "~0.6.2",
-        "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.1.2",
-        "getobject": "~0.1.0",
-        "glob": "~3.1.21",
-        "grunt-legacy-log": "~0.1.0",
-        "grunt-legacy-util": "~0.2.0",
-        "hooker": "~0.2.3",
-        "iconv-lite": "~0.2.11",
-        "js-yaml": "~2.0.5",
-        "lodash": "~0.9.2",
-        "minimatch": "~0.2.12",
-        "nopt": "~1.0.10",
-        "rimraf": "~2.2.8",
-        "underscore.string": "~2.2.1",
-        "which": "~1.0.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
-        },
-        "dateformat": {
-          "version": "1.0.2-1.2.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk="
-        },
-        "findup-sync": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
-          "requires": {
-            "glob": "~3.2.9",
-            "lodash": "~2.4.1"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "3.2.11",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-              "requires": {
-                "inherits": "2",
-                "minimatch": "0.3"
-              }
-            },
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-            },
-            "minimatch": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-              "requires": {
-                "lru-cache": "2",
-                "sigmund": "~1.0.0"
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
-        },
-        "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        },
-        "underscore.string": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
-        },
-        "which": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
-        }
-      }
-    },
-    "grunt-contrib-clean": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
-      "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
-      "requires": {
-        "rimraf": "~2.2.1"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        }
-      }
-    },
-    "grunt-contrib-concat": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.3.0.tgz",
-      "integrity": "sha1-SPoNQzbSm2U62CJaa9b4VrRIPjI=",
-      "requires": {}
-    },
-    "grunt-contrib-copy": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
-      "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
-      "requires": {}
-    },
-    "grunt-contrib-cssmin": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.6.1.tgz",
-      "integrity": "sha1-U05jK/4ZUhshw2RncVe4sR4XPvw=",
-      "requires": {
-        "clean-css": "~1.0.4",
-        "grunt-lib-contrib": "~0.6.0"
-      },
-      "dependencies": {
-        "clean-css": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-1.0.12.tgz",
-          "integrity": "sha1-5uDZd4YEZjY9kRChdCPSfNaHQwA=",
-          "requires": {
-            "commander": "1.3.x"
-          }
-        },
-        "commander": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
-          "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
-          "requires": {
-            "keypress": "0.1.x"
-          }
-        }
-      }
-    },
-    "grunt-contrib-uglify": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.2.4.tgz",
-      "integrity": "sha1-URE/KKckMlIeNeY/fxiiUf2i/Uk=",
-      "requires": {
-        "grunt-lib-contrib": "~0.6.1",
-        "uglify-js": "~2.4.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-        },
-        "source-map": {
-          "version": "0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "uglify-js": {
-          "version": "2.4.24",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-          "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
-          "requires": {
-            "async": "~0.2.6",
-            "source-map": "0.1.34",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.5.4"
-          }
-        },
-        "yargs": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
-          "requires": {
-            "camelcase": "^1.0.2",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0",
-            "wordwrap": "0.0.2"
-          }
-        }
-      }
-    },
-    "grunt-css-url-replace": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/grunt-css-url-replace/-/grunt-css-url-replace-0.2.7.tgz",
-      "integrity": "sha1-lcZb/x78FTvxfHlf0+EiLH+kp0U=",
-      "requires": {}
-    },
-    "grunt-legacy-log": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
-      "requires": {
-        "colors": "~0.6.2",
-        "grunt-legacy-log-utils": "~0.1.1",
-        "hooker": "~0.2.3",
-        "lodash": "~2.4.1",
-        "underscore.string": "~2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
-      }
-    },
-    "grunt-legacy-log-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
-      "requires": {
-        "colors": "~0.6.2",
-        "lodash": "~2.4.1",
-        "underscore.string": "~2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
-      }
-    },
-    "grunt-legacy-util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
-      "requires": {
-        "async": "~0.1.22",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
-        "hooker": "~0.2.3",
-        "lodash": "~0.9.2",
-        "underscore.string": "~2.2.1",
-        "which": "~1.0.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
-        },
-        "underscore.string": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
-        },
-        "which": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
-        }
-      }
-    },
-    "grunt-lib-contrib": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.6.1.tgz",
-      "integrity": "sha1-P1att9oG6BR5XuJBWw6+X7iQPrs=",
-      "requires": {
-        "zlib-browserify": "0.0.1"
-      }
     },
     "gulp": {
       "version": "4.0.2",
@@ -18746,11 +17754,6 @@
         "parse-passwd": "^1.0.0"
       }
     },
-    "hooker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
-    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -19323,15 +18326,6 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
-    "js-yaml": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
-      "requires": {
-        "argparse": "~ 0.1.11",
-        "esprima": "~ 1.0.2"
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -19415,11 +18409,6 @@
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
-    },
-    "keypress": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
     },
     "keyv": {
       "version": "3.1.0",
@@ -20534,6 +19523,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -22132,11 +21122,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -23209,52 +22194,10 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
       "dev": true
     },
-    "uglify": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/uglify/-/uglify-0.1.5.tgz",
-      "integrity": "sha1-iI1X770b+n+tieEdBpl16WgtVNI=",
-      "requires": {
-        "commander": "*",
-        "grunt": "0.4.5",
-        "grunt-contrib-clean": "0.5.0",
-        "grunt-contrib-concat": "0.3.0",
-        "grunt-contrib-copy": "0.5.0",
-        "grunt-contrib-cssmin": "0.6.1",
-        "grunt-contrib-uglify": "0.2.4",
-        "grunt-css-url-replace": "*",
-        "underscore": "1.4.x",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
-        }
-      }
-    },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-      "dev": true,
-      "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+      "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA=="
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -23325,11 +22268,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
-    "underscore.string": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
     },
     "undertaker": {
       "version": "1.2.1",
@@ -24224,16 +23162,6 @@
         }
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -24405,11 +23333,6 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
-    },
-    "zlib-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
-      "integrity": "sha1-T6akXQDbwV8xikr6HZr8Aljhdsw="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "npm": "7.x"
   },
   "scripts": {
+    "bundle": "./node_modules/browserify/bin/cmd.js src/js/app.js | uglifyjs -mc  > src/js/bundle.js",
     "preinstall": "rm -rf node_modules/*/.git/",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "watchify src/js/app.js -o src/js/bundle.js -v",
-    "build": "browserify src/js/app.js | uglifyjs -mc warnings=false > src/js/bundle.js",
+    "heroku-postbuild": "npm run bundle",
     "dev": "npm run watch & nodemon server.js --host 0.0.0.0",
     "start": "node server.js",
     "truffletest": "truffle test"
@@ -36,7 +37,6 @@
     "gulp-uglify": "latest",
     "nodemon": "^1.19.1",
     "truffle-flattener": "^1.4.4",
-    "uglify-js": "^3.6.0",
     "watchify": "^3.11.1"
   },
   "dependencies": {
@@ -66,7 +66,7 @@
     "passport-local": "^1.0.0",
     "qrcode": "^1.4.0",
     "truffle-hdwallet-provider": "^1.0.15",
-    "uglify": "^0.1.5",
+    "uglify-js": "^3.13.7",
     "uuid": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "ISC",
   "devDependencies": {
     "browser-sync": "latest",
-    "browserify": "^16.3.0",
     "gulp": "latest",
     "gulp-autoprefixer": "latest",
     "gulp-clean-css": "latest",
@@ -42,6 +41,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
+    "browserify": "^16.3.0",
     "connect-ensure-login": "^0.1.1",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.4",
@@ -66,6 +66,7 @@
     "passport-local": "^1.0.0",
     "qrcode": "^1.4.0",
     "truffle-hdwallet-provider": "^1.0.15",
+    "uglify": "^0.1.5",
     "uuid": "^3.3.3"
   }
 }


### PR DESCRIPTION
Description: Production deploy was failing on build step due to browserify not found error. 

Moved both browserify and uglify from dev deps to prod deps:
`npm uninstall browserify --save-dev`
`npm install browserify --save`
`npm uninstall uglify --save-dev`
`npm uninstall uglify-js --save-dev`
`npm install uglify-js --save`

Add bundle script which references browserify by location